### PR TITLE
fix(ui): badge position destroyed page overflow

### DIFF
--- a/imports/ui/components/Badges/Badges.js
+++ b/imports/ui/components/Badges/Badges.js
@@ -6,7 +6,8 @@ import PropTypes from 'prop-types';
 const styles = {
   chip: {
     display: 'inline-flex',
-    marginLeft: 8,
+    verticalAlign: 'top',
+    marginRight: 8,
     color: '#fff'
   },
   admin: {

--- a/imports/ui/components/FollowersChip/FollowersChip.js
+++ b/imports/ui/components/FollowersChip/FollowersChip.js
@@ -43,7 +43,7 @@ export class FollowersChip extends Component {
     const { followers, style } = this.props;
     let numberOfFollowers;
     if (followers && followers.length) {
-      numberOfFollowers = followers.length > 99 ? '100+' : followers.length;
+      numberOfFollowers = followers.length > 99 ? '99+' : followers.length;
     } else {
       numberOfFollowers = 0;
     }

--- a/imports/ui/components/Level/Level.js
+++ b/imports/ui/components/Level/Level.js
@@ -137,13 +137,11 @@ class Level extends Component {
           <div style={styles.header}>
             <AvatarWithStatus style={{ margin: 5 }} trophyHunter={trophyHunter} />
             <div style={{ margin: '15px 5px', flex: 1 }}>
-              <div style={{ color: universeTheme.palette.secondaryTextColor }}>
-                {title}
-                <Badges items={trophyHunter && trophyHunter.items} />
-              </div>
+              <div style={{ color: universeTheme.palette.secondaryTextColor }}>{title}</div>
               <div>{subtitle}</div>
             </div>
             <div style={{ paddingTop: 10 }}>
+              <Badges items={trophyHunter && trophyHunter.items} />
               {items}
               <FollowersChip
                 followers={trophyHunter && trophyHunter.followers}


### PR DESCRIPTION
For users with Patreon or Admin badge, the container height was too high. I moved the badges to the right side next to the followers and youtube/twitch icons.