### PR TITLE
fix(api): encode summonerName and allow cross-origin

### DIFF
--- a/src/api/endpoints/active-game/index.ts
+++ b/src/api/endpoints/active-game/index.ts
@@ -17,6 +17,9 @@ const getActiveGame = ({ platformId, summonerId, version = 'v4' }) => {
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, summonerId, version }: any = parse(req.url, true).query;
   if (!platformId || !summonerId) {
     res.writeHead(400);

--- a/src/api/endpoints/champion-mastery/index.ts
+++ b/src/api/endpoints/champion-mastery/index.ts
@@ -17,6 +17,9 @@ const getChampionMastery = ({ platformId, summonerId, championId, version = 'v4'
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, summonerId, championId, version }: any = parse(req.url, true).query;
   if (!platformId || !summonerId || !championId) {
     res.writeHead(400);

--- a/src/api/endpoints/league-positions/index.ts
+++ b/src/api/endpoints/league-positions/index.ts
@@ -17,6 +17,9 @@ const getLeaguePositions = ({ platformId, summonerId, version = 'v4' }) => {
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, summonerId, version }: any = parse(req.url, true).query;
   if (!platformId || !summonerId) {
     res.writeHead(400);

--- a/src/api/endpoints/match/index.ts
+++ b/src/api/endpoints/match/index.ts
@@ -17,6 +17,9 @@ const getMatch = ({ platformId, matchId }) => {
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, matchId }: any = parse(req.url, true).query;
   if (!platformId || !matchId) {
     res.writeHead(400);

--- a/src/api/endpoints/matchlist/index.ts
+++ b/src/api/endpoints/matchlist/index.ts
@@ -36,6 +36,9 @@ const getMatchList = ({
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, accountId, championId, beginTime, endIndex, queueId, version }: any = parse(
     req.url,
     true

--- a/src/api/endpoints/matchup/index.ts
+++ b/src/api/endpoints/matchup/index.ts
@@ -39,6 +39,9 @@ const getGameSessions = async ({ mapId, champ1Id, champ2Id }) => {
 };
 
 export default async (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { champ1Id: champ1IdString, champ2Id: champ2IdString, mapId: mapIdString }: any = parse(
     req.url,
     true

--- a/src/api/endpoints/summoner/index.ts
+++ b/src/api/endpoints/summoner/index.ts
@@ -17,14 +17,17 @@ const getSummoner = ({ platformId, summonerId, accountId, summonerName, version 
       process.env.LEAGUE_API_KEY
     }`;
   } else {
-    url = `https://${platformId}.api.riotgames.com/lol/summoner/${version}/summoners/by-name/${summonerName}?api_key=${
-      process.env.LEAGUE_API_KEY
-    }`;
+    url = `https://${platformId}.api.riotgames.com/lol/summoner/${version}/summoners/by-name/${encodeURI(
+      summonerName
+    )}?api_key=${process.env.LEAGUE_API_KEY}`;
   }
   return axios.get(url).then(response => response.data);
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, summonerId, accountId, summonerName, version }: any = parse(
     req.url,
     true

--- a/src/api/endpoints/timeline/index.ts
+++ b/src/api/endpoints/timeline/index.ts
@@ -17,6 +17,9 @@ const getTimeline = ({ platformId, matchId }) => {
 };
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, matchId }: any = parse(req.url, true).query;
   if (!platformId || !matchId) {
     res.writeHead(400);

--- a/src/api/endpoints/trophies/index.ts
+++ b/src/api/endpoints/trophies/index.ts
@@ -6,6 +6,9 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { getMatch, getTimeline } from '../../shared/th-api';
 
 export default (req: IncomingMessage, res: ServerResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
   const { platformId, matchId, summonerName }: any = parse(req.url, true).query;
   if (!platformId || !matchId || !summonerName) {
     res.writeHead(400);


### PR DESCRIPTION
We had some issues with special chars in summonerName like `Déjà Vù`.
This is fixed due to url encoding now.

In addition we allow cross-origin requests to support api calls from other applications like the new creator website.