### PR TITLE
fix(server): remove server stats on exit

### DIFF
--- a/imports/api/matchup/server/_methods.js
+++ b/imports/api/matchup/server/_methods.js
@@ -13,6 +13,11 @@ Meteor.methods({
     });
     const { champ1Id, champ2Id, mapId } = props;
 
-    return await getMatchup({ champ1Id, champ2Id, mapId });
+    try {
+      return await getMatchup({ champ1Id, champ2Id, mapId });
+    } catch (error) {
+      console.error(error.message);
+      throw error.message;
+    }
   }
 });

--- a/imports/api/server-stats/server/index.js
+++ b/imports/api/server-stats/server/index.js
@@ -27,6 +27,10 @@ export const register = ({ name }) => {
     const now = new Date();
     ServerStats.update({ name }, { $set: { connections: count, updatedAt: now } });
   }, 60000);
+
+  process.on('exit', () => {
+    ServerStats.remove({ name });
+  });
 };
 
 export const removeDead = () => {


### PR DESCRIPTION
When we release a new version, the online count is valid for a short time.
This change makes sure that the server stats are removed on exit to fix this issue.