### PR TITLE
fix(ui): trophy search by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Fixed
+- Fixed trophy search by name.
+
 ## [3.0.0] - 2019-01-12
 ### Added
 - Trophy Hunter Season 2019 started!

--- a/imports/ui/components/AllTrophies/AllTrophies.js
+++ b/imports/ui/components/AllTrophies/AllTrophies.js
@@ -82,7 +82,7 @@ class AllTrophies extends Component {
     if (onlyQuests) {
       filteredTrophies = getActiveQuestTrophies(trophyHunter);
     } else if (name) {
-      const regExp = new RegExp(escapeStringRegexp(name), 'gi');
+      const regExp = new RegExp(escapeStringRegexp(name), 'i');
       filteredTrophies = Object.values(trophies).filter(trophy => {
         return regExp.test(trophy.name) || regExp.test(trophy.description);
       });


### PR DESCRIPTION
Search for `siege` only returned `Siege Ram` and not `Siege Master` on trophies page.
