### PR TITLE
feat(ui): use two columns for creator website

### DIFF
--- a/src/creator/components/JSONEditor.tsx
+++ b/src/creator/components/JSONEditor.tsx
@@ -5,8 +5,6 @@ import { JSONEditorProps } from './types';
 
 const styles = {
   container: {
-    //width: '100%',
-    //height: '100%',
     flex: 1
   }
 };

--- a/src/creator/components/JSONEditor.tsx
+++ b/src/creator/components/JSONEditor.tsx
@@ -5,8 +5,9 @@ import { JSONEditorProps } from './types';
 
 const styles = {
   container: {
-    width: '100%',
-    height: '100%'
+    //width: '100%',
+    //height: '100%',
+    flex: 1
   }
 };
 

--- a/src/creator/components/Match.tsx
+++ b/src/creator/components/Match.tsx
@@ -7,6 +7,19 @@ import calculateTrophies from '../shared/trophies/calculateTrophies';
 
 const DynamicJSONEditor = dynamic<JSONEditorProps>(import('./JSONEditor') as any, { ssr: false });
 
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
+  },
+  views: {
+    flex: 1,
+    display: 'flex',
+    height: '100%'
+  }
+};
+
 const matchKey = 'th-creator-match';
 let lastMatch;
 try {
@@ -57,15 +70,18 @@ const Match = () => {
   };
 
   return (
-    <div>
+    // @ts-ignore
+    <div style={styles.container}>
       <LoadMatch onLoad={handleLoad} />
-      <DynamicJSONEditor
-        json={match}
-        onValidate={handleValidate}
-        mode="code"
-        onChangeText={handleChangeText}
-      />
-      <DynamicJSONEditor json={participants} mode="tree" />
+      <div style={styles.views}>
+        <DynamicJSONEditor
+          json={match}
+          onValidate={handleValidate}
+          mode="code"
+          onChangeText={handleChangeText}
+        />
+        <DynamicJSONEditor json={participants} mode="tree" />
+      </div>
     </div>
   );
 };

--- a/src/creator/pages/index.tsx
+++ b/src/creator/pages/index.tsx
@@ -2,7 +2,17 @@ import React from 'react';
 import Match from '../components/Match';
 
 export default () => (
-  <main>
-    <Match />
-  </main>
+  <>
+    <style>{`
+      html,
+      body,
+      #__next {
+        height: 100%;
+        margin: 0;
+      }
+    `}</style>
+    <main style={{ height: '100%' }}>
+      <Match />
+    </main>
+  </>
 );


### PR DESCRIPTION
fixes #79 

To make it easier for now, I change the view to full screen with two columns.

![image](https://user-images.githubusercontent.com/10058950/51141838-90f2f980-184a-11e9-8655-beb1ebcdb23a.png)

@MarlonWelter does this solve your issues?
Feel free to approve, merge and remove the branch if it does.

Otherwise we can think about another solution.
I have good experiences with https://github.com/STRML/react-grid-layout, which allows free positioning and resizing of elements. Could be useful if we add more elements.