### PR TITLE
fix(api): add region mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Fixed
+- Fixed invalid region detects which lead to new user accounts.
+
 ## [3.0.1] - 2019-01-12
 ### Fixed
 - Fixed trophy search by name.

--- a/imports/api/overwolf/normalizeRegion.js
+++ b/imports/api/overwolf/normalizeRegion.js
@@ -1,0 +1,18 @@
+const regionsMap = {
+  br1: 'br',
+  eun1: 'eune',
+  euw1: 'euw',
+  jp1: 'jp',
+  la1: 'lan',
+  la2: 'las',
+  na1: 'na',
+  oc1: 'oce',
+  tr1: 'tr'
+};
+
+const normalizeRegion = region => {
+  const normalizedRegion = regionsMap[region.toLowerCase()] || region;
+  return normalizedRegion.toUpperCase();
+};
+
+export default normalizeRegion;

--- a/imports/api/overwolf/overwolf.js
+++ b/imports/api/overwolf/overwolf.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 import { getPlatformIdByRegion } from '/imports/shared/th-api/index.ts';
+import normalizeRegion from './normalizeRegion';
 
 export default class Overwolf {
   constructor(props) {
@@ -59,7 +60,7 @@ export default class Overwolf {
   }
 
   login({ region, summonerName, overwolfUser }) {
-    region = region.toUpperCase();
+    region = normalizeRegion(region);
     try {
       const endpoint = getPlatformIdByRegion(region);
       console.log(`Use ${endpoint} platform`);


### PR DESCRIPTION
We have duplicate user accounts because of missing region mapping.
For LAN and LAS for example, we do not get the region. We get the platformId instead.
