### PR TITLE
fix(jobs): make sure to only have one jobs instance

### DIFF
--- a/src/app/imports/api/jobs/server/cleanup.js
+++ b/src/app/imports/api/jobs/server/cleanup.js
@@ -4,15 +4,14 @@ import Notifications from '/imports/api/notifications/notifications';
 import SummonerStats from '/imports/api/summoner-stats/summonerStats';
 import TrophyHunters from '/imports/api/trophy-hunters/trophyHunters';
 import { UsersSessions } from 'meteor/lmachens:user-presence';
-import { removeDead } from '../../server-stats/server';
 import { getPlatformIdByRegion, getActiveGame } from '/imports/shared/th-api/index.ts';
 
 async function cleanup(job, cb) {
   console.log('cleanup'.blue, 'start');
 
-  // Remove old cleanup jobs
   Jobs.remove({ type: 'cleanup', status: 'completed' });
 
+  // Remove old cleanup jobs
   const veryLongPast = new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000); // 3 months ago
   const past = new Date(Date.now() - 90 * 60 * 1000); // 90 minutes ago
   const shortPast = new Date(Date.now() - 10 * 60 * 1000); // 10 minutes ago
@@ -148,8 +147,6 @@ async function cleanup(job, cb) {
     removedNotifications
   );
 
-  const removedDeadServers = removeDead();
-
   job.log('Cleaned up');
   job.done({
     oldGameSessions,
@@ -159,11 +156,7 @@ async function cleanup(job, cb) {
     oldMatchesInProgress,
     reprocessFailed,
     removedSummonerStats,
-    removedNotifications,
-    removedDeadServers
-  });
-  job.rerun({
-    wait: 15 * 60 * 1000 // rerun in 15 minutes
+    removedNotifications
   });
   cb();
 }

--- a/src/app/imports/api/jobs/server/drawLotteryWinners.js
+++ b/src/app/imports/api/jobs/server/drawLotteryWinners.js
@@ -7,6 +7,8 @@ import TrophyHunters from '/imports/api/trophy-hunters/trophyHunters';
 const drawLotteryWinners = (job, cb) => {
   console.log('drawLotteryWinners'.blue, 'start');
 
+  Jobs.remove({ type: 'drawLotteryWinners', status: 'completed' });
+
   const { lotteryId } = job.data;
 
   const lottery = Lotteries.findOne(lotteryId);

--- a/src/app/imports/api/server-stats/server/index.js
+++ b/src/app/imports/api/server-stats/server/index.js
@@ -10,6 +10,7 @@ const getConnections = () => {
 };
 
 export const register = ({ name }) => {
+  console.log('register', name);
   const now = new Date();
   ServerStats.upsert(
     { name },
@@ -31,9 +32,4 @@ export const register = ({ name }) => {
   process.on('exit', () => {
     ServerStats.remove({ name });
   });
-};
-
-export const removeDead = () => {
-  const shortPast = new Date(Date.now() - 5 * 60 * 1000);
-  return ServerStats.remove({ updatedAt: { $lt: shortPast } });
 };

--- a/src/app/imports/api/status/server/jobs/_riotApiStatus.js
+++ b/src/app/imports/api/status/server/jobs/_riotApiStatus.js
@@ -63,6 +63,7 @@ const refreshRiotApiStatus = (job, cb) => {
 export const processRefreshRiotApiStatusJob = () => {
   Jobs.remove({ type: 'refreshRiotApiStatus' });
   new Job.processJobs('Jobs', 'refreshRiotApiStatus', refreshRiotApiStatus);
+
   new Job(Jobs, 'refreshRiotApiStatus', {})
     .repeat({
       repeats: Job.forever,

--- a/src/app/imports/startup/app/server/hostname.js
+++ b/src/app/imports/startup/app/server/hostname.js
@@ -1,0 +1,5 @@
+import os from 'os';
+
+const hostname = os.hostname();
+
+export default hostname;

--- a/src/app/imports/startup/app/server/jobs.js
+++ b/src/app/imports/startup/app/server/jobs.js
@@ -8,27 +8,37 @@ import drawLotteryWinners from '/imports/api/jobs/server/drawLotteryWinners';
 import refreshMatchForGameSession from '/imports/api/jobs/server/refreshMatchForGameSession';
 import { refreshStreamsJob } from '/imports/api/twitch-api/server/refreshStreamsJob';
 import { updateChampionGGStatsJob } from '/imports/api/champions/server/jobs';
+import ServerStats from '/imports/api/server-stats/server/collection';
+import hostname from './hostname';
 
-Meteor.startup(function() {
+const processJobs = () => {
+  console.log('Promoted to process jobs');
   // Start the Jobs queue running
   Jobs.startJobServer();
 
   Jobs.remove({ type: 'cleanup' });
-  new Job.processJobs('Jobs', 'cleanup', cleanup);
+  new Job.processJobs('Jobs', 'cleanup', { workTimeout: 60000 }, cleanup);
+
+  new Job(Jobs, 'cleanup', {})
+    .repeat({
+      repeats: Job.forever,
+      wait: 15 * 60000
+    })
+    .delay(60 * 1000)
+    .save();
 
   new Job.processJobs(
     'Jobs',
     'refreshMatchForGameSession',
-    {
-      concurrency: 1
-    },
+    { workTimeout: 60000 },
     refreshMatchForGameSession
   );
 
-  new Job.processJobs('Jobs', 'drawLotteryWinners', drawLotteryWinners);
+  new Job.processJobs('Jobs', 'drawLotteryWinners', { workTimeout: 60000 }, drawLotteryWinners);
 
   Jobs.remove({ type: 'refreshStreams' });
-  new Job.processJobs('Jobs', 'refreshStreams', refreshStreamsJob);
+  new Job.processJobs('Jobs', 'refreshStreams', { workTimeout: 60000 }, refreshStreamsJob);
+
   new Job(Jobs, 'refreshStreams', {})
     .repeat({
       repeats: Job.forever,
@@ -37,7 +47,13 @@ Meteor.startup(function() {
     .save();
 
   Jobs.remove({ type: 'updateChampionGGStats' });
-  new Job.processJobs('Jobs', 'updateChampionGGStats', updateChampionGGStatsJob);
+
+  new Job.processJobs(
+    'Jobs',
+    'updateChampionGGStats',
+    { workTimeout: 7200000 },
+    updateChampionGGStatsJob
+  );
 
   new Job(Jobs, 'updateChampionGGStats', {})
     .repeat({
@@ -48,4 +64,22 @@ Meteor.startup(function() {
     .save();
 
   processRefreshRiotApiStatusJob();
+};
+
+Meteor.startup(() => {
+  let checkInstanceInterval;
+  const checkInstance = () => {
+    // Every instance should remove dead servers from ServerStats collection
+    const shortPast = new Date(Date.now() - 5 * 60 * 1000);
+    ServerStats.remove({ updatedAt: { $lt: shortPast } });
+
+    const oldestInstance = ServerStats.findOne({}, { sort: { createdAt: 1 } });
+    if (oldestInstance.name === hostname) {
+      processJobs();
+      clearInterval(checkInstanceInterval);
+    }
+  };
+
+  checkInstanceInterval = Meteor.setInterval(checkInstance, 60000);
+  checkInstance();
 });

--- a/src/app/imports/startup/app/server/user-presence.js
+++ b/src/app/imports/startup/app/server/user-presence.js
@@ -3,13 +3,11 @@ import { UserPresence, UserPresenceMonitor } from 'meteor/lmachens:user-presence
 import { InstanceStatus } from 'meteor/lmachens:multiple-instances-status';
 import { Meteor } from 'meteor/meteor';
 import TrophyHunters from '/imports/api/trophy-hunters/trophyHunters';
-import os from 'os';
 import { register } from '/imports/api/server-stats/server';
+import hostname from './hostname';
 
-const hostname = os.hostname();
-const name = `app-${hostname}`;
 Meteor.startup(function() {
-  InstanceStatus.registerInstance(name);
+  InstanceStatus.registerInstance(hostname);
   // Listen for new connections, login, logoff and application exit to manage user status and register methods to be used by client to set user status and default status
   UserPresence.start(TrophyHunters);
   // Active logs for every changes
@@ -17,6 +15,5 @@ Meteor.startup(function() {
   UserPresenceMonitor.start(TrophyHunters);
 
   //UserPresence.activeLogs();
+  register({ name: hostname });
 });
-
-register({ name });


### PR DESCRIPTION
This PR makes sure that we don't have multiple server processing the jobs. There could be issues if matches are processed on the same time when we increase the rank for other players.