### PR TITLE
fix: trigger getSummonerInfo on league patch finish

### DIFF
--- a/src/overwolf/development/manifest.json
+++ b/src/overwolf/development/manifest.json
@@ -3,7 +3,7 @@
   "type": "WebApp",
   "meta": {
     "name": "Trophy Hunter (dev)",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "minimum-overwolf-version": "0.108.209.0",
     "author": "Trophy Hunter",
     "icon": "src/assets/IconMouseOver.png",

--- a/src/overwolf/production/manifest.json
+++ b/src/overwolf/production/manifest.json
@@ -3,7 +3,7 @@
   "type": "WebApp",
   "meta": {
     "name": "Trophy Hunter",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "minimum-overwolf-version": "0.108.209.0",
     "author": "Trophy Hunter",
     "icon": "src/assets/IconMouseOver.png",

--- a/src/overwolf/shared/lib/launcherListener.js
+++ b/src/overwolf/shared/lib/launcherListener.js
@@ -209,7 +209,7 @@ class LauncherListener {
         status
       );
     }
-    if (/LOGIN_HIDE_EVENT/.test(data)) {
+    if (/LOGIN_HIDE_EVENT/.test(data) || /riot__rclient__remove_unneeded_releases/.test(data)) {
       this.getSummonerInfo();
     }
   };
@@ -296,7 +296,7 @@ class LauncherListener {
 
   processLogLine = line => {
     const champSelect = this.getChampSelect(line);
-    if (/LOGIN_HIDE_EVENT/.test(line)) {
+    if (/LOGIN_HIDE_EVENT/.test(line) || /riot__rclient__remove_unneeded_releases/.test(line)) {
       this.getSummonerInfo();
     } else if (champSelect) {
       //console.log('champSelect');


### PR DESCRIPTION
We wait for `LOGIN_HIDE_EVENT` in the league log files before we get the logged in summoner.
But this line is not available when League is updating.
Instead we could wait for `riot__rclient__remove_unneeded_releases`.