### PR TITLE
feat: add trophies detection by champion until summonerName is available

### DIFF
--- a/src/api/endpoints/trophies/index.ts
+++ b/src/api/endpoints/trophies/index.ts
@@ -9,8 +9,8 @@ export default (req: IncomingMessage, res: ServerResponse) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 
-  const { platformId, matchId, summonerName }: any = parse(req.url, true).query;
-  if (!platformId || !matchId || !summonerName) {
+  const { platformId, matchId, summonerName, championId }: any = parse(req.url, true).query;
+  if (!platformId || !matchId || (!summonerName && !championId)) {
     res.writeHead(400);
     return res.end('Invalid query');
   }
@@ -23,7 +23,11 @@ export default (req: IncomingMessage, res: ServerResponse) => {
     .then(
       axios.spread((match, timeline) => {
         match.timeline = timeline;
-        const extendedMatchResult = extendMatchResult({ matchResult: match, summonerName });
+        const extendedMatchResult = extendMatchResult({
+          matchResult: match,
+          summonerName,
+          championId: parseInt(championId || '-1')
+        });
         const trophiesObtained = calculateTrophies({ extendedMatchResult });
         const result = {
           data: trophiesObtained,

--- a/src/shared/matches/extendMatchResult/index.ts
+++ b/src/shared/matches/extendMatchResult/index.ts
@@ -40,12 +40,14 @@ interface ExtendMatchResultProps {
   summonerId?: string | number;
   summonerName?: string;
   matchExtensionParameters?: any;
+  championId?: number;
 }
 function extendMatchResult({
   matchResult,
   summonerId,
   summonerName,
-  matchExtensionParameters
+  matchExtensionParameters,
+  championId
 }: ExtendMatchResultProps) {
   matchExtensionParameters = {
     withTimeline: true,
@@ -62,6 +64,17 @@ function extendMatchResult({
       summonerId,
       summonerName
     });
+    if (!extendedMatchResult.participantIdentity && championId) {
+      const participant = extendedMatchResult.participants.find(
+        participant => participant.championId === championId
+      );
+      if (participant) {
+        const participantIdentity = extendedMatchResult.participantIdentities.find(
+          participantIdentity => participantIdentity.participantId === participant.participantId
+        );
+        extendedMatchResult.participantIdentity = participantIdentity;
+      }
+    }
   }
   if (matchExtensionParameters.extendStatsParticipantIds.length === 0) {
     matchExtensionParameters.extendStatsParticipantIds.push(

--- a/src/shared/th-api/getTrophies.ts
+++ b/src/shared/th-api/getTrophies.ts
@@ -8,14 +8,16 @@ const cache = new NodeCache({
   stdTTL: 100 // seconds
 });
 
-const getTrophies = ({ platformId, matchId, summonerName }) => {
-  const key = `${platformId}&${matchId}&${summonerName}`;
+const getTrophies = ({ platformId, matchId, summonerName, championId }) => {
+  const key = `${platformId}&${matchId}&${summonerName}&${championId}`;
   const data = cache.get(key);
   if (data) {
     return new Promise(resolve => resolve(data));
   }
   return axios
-    .get(`${apiEndpoint}?platformId=${platformId}&matchId=${matchId}&summonerName=${summonerName}`)
+    .get(
+      `${apiEndpoint}?platformId=${platformId}&matchId=${matchId}&summonerName=${summonerName}&championId=${championId}`
+    )
     .then(response => {
       if (response.data) {
         cache.set(key, response.data);


### PR DESCRIPTION
Overwolf API doesn't support `summonerName` right now which is necessary for Riot API v4. 
It will be implemented in ~2 weeks. In the meantime, we can workaround it and use `championId` as identifier.