### PR TITLE
fix: @material-ui/styles install usage was incorrect

### DIFF
--- a/src/shelf/bootstrap.js
+++ b/src/shelf/bootstrap.js
@@ -1,4 +1,3 @@
 // https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users
-import { install } from '@material-ui/styles';
-
+const install = require('@material-ui/styles').install;
 install();

--- a/src/shelf/next.config.js
+++ b/src/shelf/next.config.js
@@ -1,6 +1,4 @@
-// https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users
-const install = require('@material-ui/styles').install;
-install();
+require('./bootstrap');
 
 // Typescript workaround: https://github.com/zeit/next.js/issues/5750#issuecomment-442313585
 const { PHASE_PRODUCTION_SERVER } =
@@ -23,6 +21,14 @@ module.exports = phase => {
   return withTypescript({
     webpack(config) {
       config.resolve.symlinks = false;
+      const oldEntry = config.entry;
+      config.entry = () => {
+        return oldEntry().then(entry => {
+          if (config.name === 'server') return entry;
+          entry['static/runtime/main.js'] = ['./bootstrap.js', ...entry['static/runtime/main.js']];
+          return entry;
+        });
+      };
       return config;
     },
     target: 'serverless'

--- a/src/shelf/pages/_app.tsx
+++ b/src/shelf/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { ThemeProvider } from '@material-ui/styles';
 import App, { Container } from 'next/app';
 import React from 'react';
-import './_bootstrap';
 import theme from './_theme';
 
 export default class MyApp extends App<any> {

--- a/src/www/bootstrap.js
+++ b/src/www/bootstrap.js
@@ -1,4 +1,3 @@
 // https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users
-import { install } from '@material-ui/styles';
-
+const install = require('@material-ui/styles').install;
 install();

--- a/src/www/next.config.js
+++ b/src/www/next.config.js
@@ -1,6 +1,4 @@
-// https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users
-const install = require('@material-ui/styles').install;
-install();
+require('./bootstrap');
 
 // Typescript workaround: https://github.com/zeit/next.js/issues/5750#issuecomment-442313585
 const { PHASE_PRODUCTION_SERVER } =
@@ -23,6 +21,14 @@ module.exports = phase => {
   return withTypescript({
     webpack(config) {
       config.resolve.symlinks = false;
+      const oldEntry = config.entry;
+      config.entry = () => {
+        return oldEntry().then(entry => {
+          if (config.name === 'server') return entry;
+          entry['static/runtime/main.js'] = ['./bootstrap.js', ...entry['static/runtime/main.js']];
+          return entry;
+        });
+      };
       return config;
     },
     target: 'serverless'

--- a/src/www/pages/_app.tsx
+++ b/src/www/pages/_app.tsx
@@ -2,7 +2,6 @@ import { ThemeProvider } from '@material-ui/styles';
 import App, { Container } from 'next/app';
 import Head from 'next/head';
 import React from 'react';
-import './_bootstrap';
 import theme from './_theme';
 
 export default class MyApp extends App<any> {


### PR DESCRIPTION
This is hacky and looks weired, but I don't find a better solution right now.
https://material-ui.com/css-in-js/basics/#migration-for-material-ui-core-users
it is required that the bootstrap.js is not in the same bundle, it should be in a different file.

this had the effect, that sometimes the install() was called too late and css messed up.

at least it is a temporary solution until material-ui uses the new styling as default