### PR TITLE
feat: use discord instead of slack for feedback

### DIFF
--- a/src/app/imports/api/alerts/alerts.js
+++ b/src/app/imports/api/alerts/alerts.js
@@ -28,6 +28,18 @@ class Alerts {
     };
     return this._post(slack.webhook, callOptions);
   }
+
+  sendToDiscord(data) {
+    const { discord } = Meteor.settings;
+    if (!discord || !discord.webhook) {
+      throw new Meteor.Error('settings', 'discord is empty');
+    }
+
+    const callOptions = {
+      data
+    };
+    return this._post(discord.webhook, callOptions);
+  }
 }
 
 const alerts = new Alerts();

--- a/src/app/imports/api/alerts/server/methods.js
+++ b/src/app/imports/api/alerts/server/methods.js
@@ -6,5 +6,9 @@ Meteor.methods({
   sendToSlack(message) {
     check(message, Object);
     alerts.sendToSlack(message);
+  },
+  sendToDiscord(message) {
+    check(message, Object);
+    alerts.sendToDiscord(message);
   }
 });

--- a/src/app/imports/api/trophy-hunters/server/methods/_addFeedback.js
+++ b/src/app/imports/api/trophy-hunters/server/methods/_addFeedback.js
@@ -1,51 +1,35 @@
 import { Meteor } from 'meteor/meteor';
 import alerts from '../../../alerts/alerts';
-import { getProfileIcon } from '../../../riot-api/staticData';
 import moment from 'moment';
 
-const addFeedback = function(
-  details,
-  { createdAt, overwolfUser, summonerName, region, profileIconId }
-) {
-  alerts.sendToSlack({
-    username: 'Feedback Alerts',
-    icon_emoji: ':information_source:',
-    text: 'New feedback!',
-    attachments: [
+const addFeedback = function(details, { createdAt, overwolfUser, summonerName, region }) {
+  alerts.sendToDiscord({
+    username: 'Trophy Hunter Bot',
+    content: 'New feedback!',
+    embeds: [
       {
-        author_name: `${summonerName} (${region})`,
-        author_icon: getProfileIcon(profileIconId),
-        fields: [
-          {
-            title: 'Rating',
-            value: `${details.rating}/5`,
-            short: false
-          },
-          {
-            title: 'Text',
-            value: details.text,
-            short: false
-          },
-          {
-            title: 'Registered at',
-            value: moment(createdAt).format('DD/MM/YYYY - hh:mma'),
-            short: false
-          },
-          {
-            title: 'Version',
-            value: `App: ${overwolfUser && overwolfUser.appVersion}\nServer: ${
-              Meteor.settings.public.version
-            }\nOverwolf: ${overwolfUser && overwolfUser.overwolfVersion}\nChannel: ${overwolfUser &&
-              overwolfUser.channel}\nPartner ID: ${overwolfUser && overwolfUser.partnerId}`,
-            short: true
-          },
-          {
-            title: 'Overwolf user',
-            value: `Username: ${overwolfUser && overwolfUser.username}\nUser ID: ${overwolfUser &&
-              overwolfUser.userId}\nMachine ID: ${overwolfUser && overwolfUser.machineId}`,
-            short: true
-          }
-        ]
+        title: 'Rating',
+        description: `${details.rating} of 5 stars`
+      },
+      {
+        title: 'Text',
+        description: details.text
+      },
+      {
+        title: 'Summoner',
+        description: `${summonerName} (${region})`
+      },
+      {
+        title: 'Registered at',
+        description: moment(createdAt).calendar()
+      },
+      {
+        title: 'Version',
+        description: `App: ${overwolfUser && overwolfUser.appVersion}\nServer: ${
+          Meteor.settings.public.version
+        }\nOverwolf: ${overwolfUser && overwolfUser.overwolfVersion}\nChannel: ${overwolfUser &&
+          overwolfUser.channel}\nPartner ID: ${overwolfUser && overwolfUser.partnerId}`,
+        short: true
       }
     ]
   });

--- a/src/app/imports/ui/components/Tree/Tree.js
+++ b/src/app/imports/ui/components/Tree/Tree.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import TreeItem from '../TreeItem';
+import trophies from '/imports/shared/trophies/index.ts';
 
 class Tree extends React.Component {
   render() {

--- a/src/app/public/CHANGELOG.md
+++ b/src/app/public/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Added
+- Connect feedback form to our Discord server.
+
 ## [3.3.0] - 2019-02-08
 ### Added
 - Added new trophy [trophy:mudkipsPenta].

--- a/src/app/template.settings.json
+++ b/src/app/template.settings.json
@@ -11,6 +11,9 @@
   "slack": {
     "webhook": "https://hooks.slack.com/services/XXX"
   },
+  "discord": {
+    "webhook": "https://discordapp.com/api/webhooks/XXX/XXX"
+  },
   "patreon": {
     "id": "XXX",
     "secret": "XXX",


### PR DESCRIPTION
- **Please check these requirements**

  - [x] The commit message follows [our guidelines](https://www.conventionalcommits.org/)
  - [x] Docs/Changelog have been added / updated (for bug fixes / features)
  

- **What is the current behavior?** (You can also link to an open issue here)

We use our private Slack for feedback messages.

- **What is the new behavior (if this is a feature change)?**

Make it public -> use our Discord Server.

- **How did you test your changes?**

![image](https://user-images.githubusercontent.com/10058950/52525183-1e890400-2ca6-11e9-95cb-154b181dcc84.png)

- **What changes might devs need to make due to this PR?** (like updating settings or deps with `yarn install`?)

Add webhook url to settings.json if you want to use it.

- **Other information**:

