### PR TITLE
[app] feat: use played-together and match api

### DIFF
--- a/src/app/imports/api/badges/_generateBadgesByParticipantPerformance.js
+++ b/src/app/imports/api/badges/_generateBadgesByParticipantPerformance.js
@@ -15,21 +15,21 @@ export const generateBadgesByParticipantPerformance = ({
   if (trophyHunter) {
     result[badges.trophyHunter.name] = trophyHunter;
   }
-  if (playedTogether && playedTogether[participant.summonerId]) {
-    const premades = Object.entries(playedTogether[participant.summonerId].with).reduce(
-      (acc, [summonerId, times]) => {
+  if (playedTogether && playedTogether[participant.summonerName]) {
+    const premades = Object.entries(playedTogether[participant.summonerName].with).reduce(
+      (acc, [summonerName, times]) => {
         const playedWithParticipant = participants.find(
-          p => p.summonerId === safeParseInt(summonerId)
+          p => p.summonerName === safeParseInt(summonerName)
         );
         if (times > 1 && playedWithParticipant) {
           let matchesSince;
           if (
-            playedTogether[participant.summonerId].matchesSince >
-            playedTogether[summonerId].matchesSince
+            playedTogether[participant.summonerName].matchesSince >
+            playedTogether[summonerName].matchesSince
           ) {
-            matchesSince = playedTogether[participant.summonerId].matchesSince;
+            matchesSince = playedTogether[participant.summonerName].matchesSince;
           } else {
-            matchesSince = playedTogether[summonerId].matchesSince;
+            matchesSince = playedTogether[summonerName].matchesSince;
           }
           acc.push({
             summonerName: playedWithParticipant.summonerName,

--- a/src/app/imports/store/reducers/_playedTogether.js
+++ b/src/app/imports/store/reducers/_playedTogether.js
@@ -33,7 +33,7 @@ const playedTogether = (
   }
 };
 
-export const playedTogetherBySummonerIds = (state = {}, action) => {
+export const playedTogetherBySummonerNames = (state = {}, action) => {
   const { type, data } = action;
   switch (type) {
     case RECEIVE_PLAYED_TOGETHER:

--- a/src/app/imports/store/reducers/index.js
+++ b/src/app/imports/store/reducers/index.js
@@ -9,7 +9,7 @@ import { matchesByMatchup } from './_matchupMatches';
 import { matchesByParticipant } from './_participantMatches';
 import { participantsHeatmapByParticipant } from './_participantsHeatmap';
 import { participantsPerformanceByParticipant } from './_participantsPerformance';
-import { playedTogetherBySummonerIds } from './_playedTogether';
+import { playedTogetherBySummonerNames } from './_playedTogether';
 import { statsByMatchup } from './_matchupStats';
 import { trophyStatsByTrophyName } from './_trophyStats';
 import { uiStates } from './_uiStates';
@@ -26,7 +26,7 @@ const reducers = combineReducers({
   matchesByParticipant,
   participantsHeatmapByParticipant,
   participantsPerformanceByParticipant,
-  playedTogetherBySummonerIds,
+  playedTogetherBySummonerNames,
   statsByMatchup,
   uiStates
 });

--- a/src/app/imports/ui/components/LiveMatch/boxes/partials/_Participant.js
+++ b/src/app/imports/ui/components/LiveMatch/boxes/partials/_Participant.js
@@ -2,7 +2,6 @@ import { IconButtonV2, Typography, withStyles } from '../../../generic';
 import React, { PureComponent } from 'react';
 import {
   fetchParticipantPerformanceIfNeeded,
-  fetchPlayedTogetherIfNeeded,
   selectFirstTeamTarget,
   selectMapTarget,
   selectRole,
@@ -145,32 +144,17 @@ class Participant extends PureComponent {
     const {
       fetchParticipantPerformanceIfNeeded,
       identifier,
-      playedTogetherIdentifier,
-      fetchPlayedTogetherIfNeeded,
       fetchChampionStatsIfNeeded,
       participant
     } = this.props;
     if (identifier) fetchParticipantPerformanceIfNeeded(identifier);
-    if (playedTogetherIdentifier) fetchPlayedTogetherIfNeeded(playedTogetherIdentifier);
     if (participant.championId) fetchChampionStatsIfNeeded(participant.championId);
   }
 
   componentDidUpdate(prevProps) {
-    const {
-      fetchParticipantPerformanceIfNeeded,
-      identifier,
-      playedTogetherIdentifier,
-      fetchPlayedTogetherIfNeeded,
-      participant
-    } = this.props;
+    const { fetchParticipantPerformanceIfNeeded, identifier, participant } = this.props;
     if (identifier !== prevProps.identifier && identifier) {
       fetchParticipantPerformanceIfNeeded(identifier);
-    }
-    if (
-      playedTogetherIdentifier !== prevProps.playedTogetherIdentifier &&
-      playedTogetherIdentifier
-    ) {
-      fetchPlayedTogetherIfNeeded(playedTogetherIdentifier);
     }
     if (participant.championId !== prevProps.championId)
       fetchChampionStatsIfNeeded(participant.championId);
@@ -328,8 +312,6 @@ Participant.propTypes = {
   platformId: PropTypes.string.isRequired,
   selectRole: PropTypes.func.isRequired,
   identifier: PropTypes.string.isRequired,
-  playedTogetherIdentifier: PropTypes.string,
-  fetchPlayedTogetherIfNeeded: PropTypes.func.isRequired,
   championMastery: PropTypes.object,
   summonerLevel: PropTypes.number,
   invertTeams: PropTypes.bool,
@@ -349,7 +331,7 @@ const mapStateToProps = (
       secondTeam,
       invertTeams
     },
-    playedTogetherBySummonerIds
+    playedTogetherBySummonerNames
   },
   { participant }
 ) => {
@@ -361,9 +343,9 @@ const mapStateToProps = (
   const summonerLevel = participantPerformance.summonerLevel;
 
   const participants = [...firstTeam, ...secondTeam];
-  const summonerIds = participants.map(participant => participant.summonerId);
-  const playedTogetherIdentifier = `${platformId}&${summonerIds.join('|')}`;
-  const playedTogether = playedTogetherBySummonerIds[playedTogetherIdentifier] || {};
+  const summonerNames = participants.map(participant => participant.summonerName);
+  const playedTogetherIdentifier = `${platformId}&${summonerNames.join('|th|')}`;
+  const playedTogether = playedTogetherBySummonerNames[playedTogetherIdentifier] || {};
   const badges = generateBadgesByParticipantPerformance({
     participantPerformance,
     participant,
@@ -397,7 +379,6 @@ const mapDispatchToProps = dispatch => {
       fetchParticipantPerformanceIfNeeded,
       dispatch
     ),
-    fetchPlayedTogetherIfNeeded: bindActionCreators(fetchPlayedTogetherIfNeeded, dispatch),
     selectRole: bindActionCreators(selectRole, dispatch),
     fetchChampionStatsIfNeeded: bindActionCreators(fetchChampionStatsIfNeeded, dispatch)
   };

--- a/src/app/imports/ui/layouts/OverlayLayout.js
+++ b/src/app/imports/ui/layouts/OverlayLayout.js
@@ -154,6 +154,7 @@ class OverlayLayout extends Component {
     this.busyRefresh = true;
     Meteor.call('startMatch', () => {
       this.busyRefresh = false;
+      location.reload();
     });
   };
 

--- a/src/app/imports/ui/pages/match/Match.js
+++ b/src/app/imports/ui/pages/match/Match.js
@@ -6,7 +6,6 @@ import {
 
 import { Button } from '../../components/generic';
 import LoadingComponent from '../../components/loading/LoadingComponent';
-import { Meteor } from 'meteor/meteor';
 import { OpenInNewIcon } from '../../components/icons';
 import PropTypes from 'prop-types';
 import Timeline from '../../components/Timeline';
@@ -15,6 +14,7 @@ import champions from '/imports/shared/riot-api/champions.ts';
 import extendMatchResult from '/imports/shared/matches/extendMatchResult/index.ts';
 import moment from 'moment';
 import universeTheme from '../../layouts/universeTheme';
+import { getMatchWithTimeline } from '/imports/shared/th-api/index.ts';
 
 const styles = {
   container: {
@@ -67,8 +67,8 @@ class Match extends Component {
   updateMatchWithTimeline({ matchId, platformId, summonerId, summonerName }) {
     matchId = parseInt(matchId);
     summonerId = parseInt(summonerId) || summonerId;
-    Meteor.call('getMatchWithTimeline', matchId, platformId, (error, result) => {
-      if (result) {
+    getMatchWithTimeline({ platformId, matchId })
+      .then(result => {
         const extendedMatchResult = extendMatchResult({
           matchResult: result,
           summonerId,
@@ -79,14 +79,14 @@ class Match extends Component {
           matchWithTimeline: result,
           extendedMatchResult: extendedMatchResult
         });
-      } else {
+      })
+      .catch(() => {
         this.setState({
           extendedMatchResult: null,
           matchWithTimeline: null,
           noData: true
         });
-      }
-    });
+      });
   }
 
   render() {

--- a/src/app/public/CHANGELOG.md
+++ b/src/app/public/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 - Connect feedback form to our Discord server.
+### Changed
+- Optimize calculation of "Played together".
+- Optimize loading of recent match.
 ### Removed
 - Removed legacy access to old matches and summoner accounts.
 

--- a/src/shared/th-api/getPlayedTogether.ts
+++ b/src/shared/th-api/getPlayedTogether.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import NodeCache from 'node-cache';
+
+const apiEndpoint = process.env.PLAYED_TOGETHER_API_ENDPOINT || 'https://api.th.gl/played-together';
+
+const cache = new NodeCache({
+  checkperiod: 120, // seconds
+  stdTTL: 100 // seconds
+});
+
+const getPlayedTogether = ({ platformId, summonerNames }) => {
+  const key = `${platformId}&${JSON.stringify(summonerNames)}`;
+  const data = cache.get(key);
+  if (data) {
+    return new Promise(resolve => resolve(data));
+  }
+  const encodedSummonerNames = summonerNames.map(
+    summonerName => `&summonerName=${encodeURI(summonerName)}`
+  );
+  return axios
+    .get(`${apiEndpoint}?platformId=${platformId}${encodedSummonerNames.join('')}`)
+    .then(response => {
+      if (response.data) {
+        cache.set(key, response.data);
+      }
+      return response.data;
+    });
+};
+
+export default getPlayedTogether;

--- a/src/shared/th-api/index.ts
+++ b/src/shared/th-api/index.ts
@@ -2,6 +2,7 @@ export { default as getActiveGame } from './getActiveGame';
 export { default as getChampionMastery } from './getChampionMastery';
 export { default as getLeaguePositions } from './getLeaguePositions';
 export { default as getPlatformIdByRegion } from './getPlatformIdByRegion';
+export { default as getPlayedTogether } from './getPlayedTogether';
 export { default as getMatch } from './getMatch';
 export { default as getMatchList } from './getMatchList';
 export { default as getMatchup } from './getMatchup';


### PR DESCRIPTION
- **Please check these requirements**

  - [x] The commit message follows [our guidelines](https://www.conventionalcommits.org/)
  - [x] Docs/Changelog have been added / updated (for bug fixes / features)
  

- **What is the current behavior?** (You can also link to an open issue here)

a: If a user loads a match, it is loaded by the app server which loads it from the api server. It would be possible to load it from the api server directly. 
b: played together stats are loaded for every participant (up to 10 times), but it is only required one time. And the app server redirects the data from the api server.

- **What is the new behavior (if this is a feature change)?**

a: users are directly connected to the api server
b: users are directly connected to the api server and the stats are only loaded once.

- **How did you test your changes?**

opened overlay and inspected network

- **What changes might devs need to make due to this PR?** (like updating settings or deps with `yarn install`?)



- **Other information**:

