### PR TITLE
fix: use different discord widget cluster

### DIFF
--- a/packages/overwolf/development/manifest.json
+++ b/packages/overwolf/development/manifest.json
@@ -3,7 +3,7 @@
   "type": "WebApp",
   "meta": {
     "name": "Trophy Hunter (dev)",
-    "version": "3.0.2",
+    "version": "3.4.0",
     "minimum-overwolf-version": "0.108.209.0",
     "author": "Trophy Hunter",
     "icon": "src/assets/IconMouseOver.png",

--- a/packages/overwolf/production/manifest.json
+++ b/packages/overwolf/production/manifest.json
@@ -3,7 +3,7 @@
   "type": "WebApp",
   "meta": {
     "name": "Trophy Hunter",
-    "version": "3.0.2",
+    "version": "3.4.0",
     "minimum-overwolf-version": "0.108.209.0",
     "author": "Trophy Hunter",
     "icon": "src/assets/IconMouseOver.png",

--- a/packages/overwolf/shared/windows/index.html
+++ b/packages/overwolf/shared/windows/index.html
@@ -141,11 +141,11 @@
     </div>
     <script src="http://content.overwolf.com/libs/ads/latest/owads.min.js"></script>
     <script type="module" src="index.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
+    <script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3?force=true" async defer>
       new Crate({
         server: '320539672663031818',
         channel: '320539672663031818',
-        shard: 'https://cl2.widgetbot.io'
+        shard: 'https://cl3.widgetbot.io'
       })
     </script>
   </body>


### PR DESCRIPTION
- **Please check these requirements**

  - [ ] The commit message follows [our guidelines](https://www.conventionalcommits.org/)
  - [ ] Docs/Changelog have been added / updated (for bug fixes / features)
  

- **What is the current behavior?** (You can also link to an open issue here)

Discord widget doesn't work for some users due to a Widgetbot.io issue. It is possible to fix this issue by clearing the cache/cookies but we can not force our users to do that.

- **What is the new behavior (if this is a feature change)?**

The widgetbot cluster is changed to have a fresh cache. 

- **How did you test your changes?**



- **What changes might devs need to make due to this PR?** (like updating settings or deps with `yarn install`?)



- **Other information**:

