### PR TITLE
fix: set scroll event throttling

### DIFF
--- a/packages/www/components/Parallax/Parallax.tsx
+++ b/packages/www/components/Parallax/Parallax.tsx
@@ -57,6 +57,7 @@ const Parallax: FunctionComponent<IParallaxProps> = ({
     big
   });
   const [transform, setTransform] = useState('');
+  const ticking = useRef(false);
 
   useEffect(() => {
     resetTransform();
@@ -69,7 +70,14 @@ const Parallax: FunctionComponent<IParallaxProps> = ({
   }, []);
 
   const resetTransform = () => {
-    setTransform(calculateTransform());
+    if (!ticking.current) {
+      window.requestAnimationFrame(() => {
+        setTransform(calculateTransform());
+        ticking.current = false;
+      });
+
+      ticking.current = true;
+    }
   };
 
   const parallaxClasses = classNames({


### PR DESCRIPTION
- **Please check these requirements**

  - [x] The commit message follows [our guidelines](https://www.conventionalcommits.org/)
  - [x] Docs/Changelog have been added / updated (for bug fixes / features)
  

- **What is the current behavior?** (You can also link to an open issue here)

scroll event in parallax could be fired at high rate

- **What is the new behavior (if this is a feature change)?**

applied throttling like suggested in https://developer.mozilla.org/en-US/docs/Web/Events/scroll#Scroll_event_throttling

- **How did you test your changes?**

Scrolled in desktop and mobile

- **What changes might devs need to make due to this PR?** (like updating settings or deps with `yarn install`?)



- **Other information**:

