### PR TITLE
fix: trophy blitzkrieg

### DIFF
--- a/packages/app/public/CHANGELOG.md
+++ b/packages/app/public/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### Fixed
+ - Fix [trophy:blitzkrieg]. Was awarding if anyone got a kill before level 3 rather than just the person getting the kill.
+
 ## [3.18.1] - 2019-06-10
 ### Fixed
 - Fix [trophy:revenge] on ARAM (death timer was not calculated correctly).

--- a/packages/shared/matches/extendMatchResult/extendParticipantTimelineStats.ts
+++ b/packages/shared/matches/extendMatchResult/extendParticipantTimelineStats.ts
@@ -184,7 +184,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
       domains[extendedMatchResult.mapId].buffPositions.forEach(buffPosition => {
         const distanceToBuff = Math.sqrt(
           (kill.position.x - buffPosition[0]) * (kill.position.x - buffPosition[0]) +
-            (kill.position.y - buffPosition[1]) * (kill.position.y - buffPosition[1])
+          (kill.position.y - buffPosition[1]) * (kill.position.y - buffPosition[1])
         );
         if (distanceToBuff <= 1250 && earlyEnough) {
           cursedGroundKills++;
@@ -673,7 +673,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
       const sufficientClose =
         Math.sqrt(
           (kill.position.x - otherKill.position.x) * (kill.position.x - otherKill.position.x) +
-            (kill.position.y - otherKill.position.y) * (kill.position.y - otherKill.position.y)
+          (kill.position.y - otherKill.position.y) * (kill.position.y - otherKill.position.y)
         ) <= 350;
       return in1SecFromEachOther && sufficientClose;
     }
@@ -699,7 +699,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
         const midLane =
           Math.sqrt(
             (kill.position.x - middleX) * (kill.position.x - middleX) +
-              (kill.position.y - middleY) * (kill.position.y - middleY)
+            (kill.position.y - middleY) * (kill.position.y - middleY)
           ) <= 2000;
         // adc didnt die +- 10 sec of that roaming kill
         const noADCDeath20Sec = !adcDeaths.some(
@@ -746,19 +746,19 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
       const kill1InRange =
         Math.sqrt(
           (kill1.position.x - kill2.position.x) * (kill1.position.x - kill2.position.x) +
-            (kill1.position.y - kill2.position.y) * (kill1.position.y - kill2.position.y)
+          (kill1.position.y - kill2.position.y) * (kill1.position.y - kill2.position.y)
         ) < teamFightRange;
       const kill1CloseInTime = kill2.timestamp - kill1.timestamp < teamFightTimeRange;
       const kill2InRange =
         Math.sqrt(
           (kill2.position.x - kill3.position.x) * (kill2.position.x - kill3.position.x) +
-            (kill2.position.y - kill3.position.y) * (kill2.position.y - kill3.position.y)
+          (kill2.position.y - kill3.position.y) * (kill2.position.y - kill3.position.y)
         ) < teamFightRange;
       const kill2CloseInTime = kill3.timestamp - kill2.timestamp < teamFightTimeRange;
       const kill3InRange =
         Math.sqrt(
           (kill3.position.x - kill.position.x) * (kill3.position.x - kill.position.x) +
-            (kill3.position.y - kill.position.y) * (kill3.position.y - kill.position.y)
+          (kill3.position.y - kill.position.y) * (kill3.position.y - kill.position.y)
         ) < teamFightRange;
       const kill3CloseInTime = kill.timestamp - kill3.timestamp < teamFightTimeRange;
       let noAfterKill = true;
@@ -766,7 +766,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
         const killAfterInRange =
           Math.sqrt(
             (killAfter.position.x - kill.position.x) * (killAfter.position.x - kill.position.x) +
-              (killAfter.position.y - kill.position.y) * (killAfter.position.y - kill.position.y)
+            (killAfter.position.y - kill.position.y) * (killAfter.position.y - kill.position.y)
           ) < teamFightRange;
         const killAfterCloseInTime = killAfter.timestamp - kill.timestamp < teamFightTimeRange;
         noAfterKill = !(killAfterInRange && killAfterCloseInTime);
@@ -863,7 +863,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
       teammate.participantId !== participant.participantId &&
       (teammate.stats.kills >= extendedMatchResult.maxKills &&
         teammate.stats.totalDamageDealtToChampions >=
-          participant.stats.others.maxTotalDamageDealtToChampions)
+        participant.stats.others.maxTotalDamageDealtToChampions)
   );
   participant.stats.fedTeamMateAssistsPre10 = participant.events.assists.filter(
     assist =>
@@ -894,7 +894,7 @@ export default function extendParticipantTimelineStats(extendedMatchResult, part
   ) {
     const levelThreeTime = events.participantsLevelUps[participant.participantId - 1][2].timestamp;
     participant.stats.blitzkrieg = participant.events.kills.some(
-      kill => kill.timestamp < levelThreeTime
+      kill => (kill.timestamp < levelThreeTime) && (kill.killerLevel < 3) && (kill.killerId === participant.participantId)
     );
   }
 }


### PR DESCRIPTION
- **Please check these requirements**

  - [ ] The commit message follows [our guidelines](https://www.conventionalcommits.org/)
  - [ ] Docs/Changelog have been added / updated (for bug fixes / features)
  

- **What is the current behavior?** (You can also link to an open issue here)

Blitzkrieg trophy was being awarded to a player if there was anyone in game with a kill pre-level 3.

- **What is the new behavior (if this is a feature change)?**
Now only awards to player if they get kill pre-level 3


- **How did you test your changes?**
Compared 2 matches using creator. One which bugged for a member, and one which legitimately awarded for myself.


- **What changes might devs need to make due to this PR?** (like updating settings or deps with `yarn install`?)



- **Other information**:

